### PR TITLE
Fix bugs in reconciliation process

### DIFF
--- a/app/Filament/Resources/ReconciliationResource/Pages/CreateReconciliation.php
+++ b/app/Filament/Resources/ReconciliationResource/Pages/CreateReconciliation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Filament\Resources\ReconciliationResource\Pages;
+
+use App\Filament\Resources\ReconciliationResource\ReconciliationResource;
+use App\Models\Location;
+use App\Models\ReconciliationItem;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateReconciliation extends CreateRecord
+{
+    public static string $resource = ReconciliationResource::class;
+
+    protected function afterCreate(): void
+    {
+        $reconciliation = $this->record;
+        $location = Location::find($reconciliation->location_id);
+
+        foreach ($location->storageCabinets as $storageCabinet) {
+            foreach ($storageCabinet->containers as $container) {
+                $reconciliationItem = new ReconciliationItem;
+                $reconciliationItem->container()->associate($container);
+                $reconciliationItem->reconciliation()->associate($reconciliation);
+                $reconciliationItem->save();
+            }
+        }
+
+    }
+}

--- a/app/Filament/Resources/ReconciliationResource/ReconciliationForm.php
+++ b/app/Filament/Resources/ReconciliationResource/ReconciliationForm.php
@@ -16,7 +16,6 @@ class ReconciliationForm
                 ->options([
                     'ongoing' => 'Ongoing',
                     'completed' => 'Completed',
-                    'canceled' => 'Canceled',
                     'stopped' => 'Stopped',
                 ])
                 ->required()

--- a/app/Filament/Resources/ReconciliationResource/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource/ReconciliationResource.php
@@ -37,7 +37,9 @@ class ReconciliationResource extends Resource
     {
         return [
             'index' => Pages\ListReconciliations::route('/'),
+            'create' => Pages\CreateReconciliation::route('/create'),
             'view' => Pages\ViewReconciliation::route('/{record}'),
+
         ];
     }
 }

--- a/app/Filament/Resources/ReconciliationResource/ReconciliationTable.php
+++ b/app/Filament/Resources/ReconciliationResource/ReconciliationTable.php
@@ -27,6 +27,7 @@ class ReconciliationTable
                     'stopped' => 'heroicon-o-no-symbol',
                     'ongoing' => 'heroicon-o-pencil',
                     'completed' => 'heroicon-o-check-circle',
+                    'canceled' => 'heroicon-o-exclamation-circle',
                 })
                 ->color(fn (string $state): string => match ($state) {
                     'stopped' => 'danger',

--- a/app/Livewire/ViewReconciliation.php
+++ b/app/Livewire/ViewReconciliation.php
@@ -222,17 +222,19 @@ class ViewReconciliation extends Component implements HasForms, HasTable
                             ]);
 
                             $actionLabel = $data['action'] === 'reconciled' ? 'reconciled' : 'marked as missing';
-                            Notification::make()
-                                ->title('Reconciliation Completed')
-                                ->body("Successfully $actionLabel $unreconciledCount items.")
-                                ->success()
-                                ->send();
-                        } else {
-                            Notification::make()
-                                ->title('No Items to Process')
-                                ->body('All items have already been processed.')
-                                ->info()
-                                ->send();
+
+                        }
+                        Notification::make()
+                            ->title('Reconciliation Completed')
+                            ->body("Successfully $actionLabel $unreconciledCount items.")
+                            ->success()
+                            ->send();
+                        $reconciliation = Reconciliation::find($this->reconciliation_id);
+                        if ($reconciliation) {
+                            $reconciliation->update([
+                                'status' => 'completed',
+                                'ended_at' => date('Y-m-d H:i:s'),
+                            ]);
                         }
                     }),
             ]);
@@ -264,6 +266,7 @@ class ViewReconciliation extends Component implements HasForms, HasTable
             ]);
 
             Notification::make()
+                ->title('Reconciliation successful')
                 ->success()
                 ->send();
         }


### PR DESCRIPTION
Add missing text to popup shown after scanning barcodes.

Update Complete reconciliation button to convert status to completed.

Remove unused reconciliation type from creation form.

Update create form to also create related reconciliation items.