### PR TITLE
Update Container forms to prefill location and storage cabinet values.

### DIFF
--- a/app/Filament/Resources/ContainerResource/ContainerTable.php
+++ b/app/Filament/Resources/ContainerResource/ContainerTable.php
@@ -18,7 +18,6 @@ use Filament\Tables\Actions\ExportAction;
 use Filament\Tables\Actions\ImportAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class ContainerTable
@@ -119,7 +118,15 @@ class ContainerTable
     public static function actions(): array
     {
         return [
-            EditAction::make()->slideOver(),
+            EditAction::make()
+                ->slideOver()
+                ->mutateRecordDataUsing(function (array $data): array {
+                    $container = Container::findOrFail($data['id'])->load('storageCabinet.location');
+                    $containerLocation = $container->storageCabinet->location;
+                    $data['location_id'] = $containerLocation->id;
+
+                    return $data;
+                }),
         ];
     }
 

--- a/app/Filament/Resources/StorageCabinetResource/RelationManagers/ContainersRelationManager.php
+++ b/app/Filament/Resources/StorageCabinetResource/RelationManagers/ContainersRelationManager.php
@@ -3,9 +3,7 @@
 namespace App\Filament\Resources\StorageCabinetResource\RelationManagers;
 
 use App\Models\Chemical;
-use App\Models\Location;
 use App\Models\Reconciliation;
-use App\Models\StorageCabinet;
 use App\Models\UnitOfMeasure;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -48,48 +46,7 @@ class ContainersRelationManager extends RelationManager
                     ->label('Quantity')
                     ->numeric()
                     ->required(),
-                Select::make('location_id')
-                    ->label('Location')
-                    ->dehydrated(false)
-                    ->options(function () {
 
-                        return Location::all()->pluck('room_number', 'id');
-                    })
-
-                    ->disableOptionWhen(function ($value) {
-                        $location = Location::find($value);
-
-                        return $location && $location->hasOngoingReconciliation();
-                    })
-                    ->helperText(function () {
-                        $ongoingLocations = Location::whereHas('reconciliations', function ($query) {
-                            $query->where('status', 'ongoing');
-                        })->get();
-
-                        if ($ongoingLocations->isNotEmpty()) {
-                            $locations = $ongoingLocations->pluck('room_number')->join(', ');
-
-                            return "The following locations are currently being reconciled and cannot be selected: $locations";
-                        }
-
-                        return null;
-                    })
-                    ->searchable()
-                    ->required(),
-                Select::make('storage_cabinet_id')
-                    ->label('Storage Cabinet')
-                    ->options(function ($get) {
-                        $location = $get('location_id');
-                        if ($location) {
-
-                            return StorageCabinet::where('location_id', $location)->pluck('name', 'id');
-                        }
-
-                        return StorageCabinet::all()->pluck('name', 'id');
-
-                    })
-                    ->required()
-                    ->searchable(),
                 TextInput::make('barcode')
                     ->label('Barcode')
                     ->required(),


### PR DESCRIPTION
Remove location and storage cabinet fields from relation manager. The storage cabinet field is automatically filled with the parent record's id when creating an item using the relation manager.

Update Container edit modal to fill the location field.