### PR TITLE
Sunny/fixes

### DIFF
--- a/app/Filament/Pages/CustomLogin.php
+++ b/app/Filament/Pages/CustomLogin.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\TextInput;
+use Filament\Pages\Auth\Login as BaseLogin;
+
+/**
+ * Custom login page for the admin panel.
+ * This is used to override the default login 
+ * page so that we can use a username field instead of an email field.
+ * The only thing changed in these overrides is that we 
+ * use a username field instead of an email field.
+ */
+class CustomLogin extends BaseLogin
+{
+
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        $this->getLoginFormComponent(),
+                        $this->getPasswordFormComponent(),
+                        $this->getRememberFormComponent(),
+                    ])
+                    ->statePath('data')
+            )
+        ];
+    }
+    protected function getLoginFormComponent(): Component
+    {
+        return TextInput::make('username')
+            ->label('username')
+            ->required()
+            ->autocomplete()
+            ->autofocus()
+            ->extraInputAttributes(['tabindex' => 1]);
+    }
+
+    protected function getCredentialsFromFormData(array $data): array
+    {
+        return [
+            'username' => $data['username'],
+            'password' => $data['password'],
+        ];
+    }
+
+    protected function throwFailureValidationException(): never
+    {
+        throw \Illuminate\Validation\ValidationException::withMessages([
+            'data.username' => __('filament-panels::pages/auth/login.messages.failed'),
+        ]);
+    }
+}

--- a/app/Filament/Resources/ChemicalResource/ChemicalForm.php
+++ b/app/Filament/Resources/ChemicalResource/ChemicalForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ChemicalResource;
 
+use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 
@@ -10,13 +11,19 @@ class ChemicalForm
     public static function make(): array
     {
         return [
-            TextInput::make('cas')
-                ->label('CAS #')
-                ->required(),
-            TextInput::make('name')->required(),
+            Grid::make(2)
+                ->schema([
+                    TextInput::make('cas')
+                        ->label('CAS #')
+                        ->required(),
+                    TextInput::make('name')
+                        ->required(),
+                ]),
             \App\Livewire\HazardClassSelect::make('whmisHazardClasses')
+                ->label('WHMIS Hazard Classes')
                 ->relationship('whmisHazardClasses', 'id')
-                ->required(),
+                ->required()
+                ->columnSpanFull(),
         ];
     }
 }

--- a/app/Filament/Resources/ContainerResource/ContainerResource.php
+++ b/app/Filament/Resources/ContainerResource/ContainerResource.php
@@ -28,7 +28,8 @@ class ContainerResource extends Resource
             ->filters(ContainerTable::filters())
             ->actions(ContainerTable::actions())
             ->headerActions(ContainerTable::headerActions())
-            ->bulkActions(ContainerTable::bulkActions());
+            ->bulkActions(ContainerTable::bulkActions())
+            ->groups(ContainerTable::groups());
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ContainerResource/ContainerTable.php
+++ b/app/Filament/Resources/ContainerResource/ContainerTable.php
@@ -21,6 +21,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ViewColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Grouping\Group;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
@@ -85,6 +86,21 @@ class ContainerTable
                 ->sortable(false)
                 ->width('120px'),
 
+        ];
+    }
+
+    public static function groups(): array
+    {
+        return [
+            Group::make('storageLocation.lab.room_number')
+                ->label('Lab')
+                ->collapsible(),
+            Group::make('storageLocation.name')
+                ->label('Storage Location')
+                ->getTitleFromRecordUsing(fn (Container $record): string => 
+                    $record->storageLocation->lab->room_number . ' - ' . $record->storageLocation->name
+                )
+                ->collapsible(),
         ];
     }
 

--- a/app/Filament/Resources/ReconciliationResource/Pages/CreateReconciliation.php
+++ b/app/Filament/Resources/ReconciliationResource/Pages/CreateReconciliation.php
@@ -4,26 +4,165 @@ namespace App\Filament\Resources\ReconciliationResource\Pages;
 
 use App\Filament\Resources\ReconciliationResource\ReconciliationResource;
 use App\Models\Lab;
+use App\Models\Reconciliation;
 use App\Models\ReconciliationItem;
+use Carbon\Carbon;
+use Filament\Actions;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class CreateReconciliation extends CreateRecord
 {
     public static string $resource = ReconciliationResource::class;
 
-    protected function afterCreate(): void
+    protected function handleRecordCreation(array $data): Model
     {
-        $reconciliation = $this->record;
-        $lab = Lab::find($reconciliation->lab_id);
+        $labIds = $data['lab_ids'] ?? null;
 
-        foreach ($lab->storageLocations as $storageLocation) {
-            foreach ($storageLocation->containers as $container) {
-                $reconciliationItem = new ReconciliationItem;
-                $reconciliationItem->container()->associate($container);
-                $reconciliationItem->reconciliation()->associate($reconciliation);
-                $reconciliationItem->save();
-            }
+        // If lab_ids is present, we're creating multiple reconciliations
+        if ($labIds && is_array($labIds) && !empty($labIds)) {
+            return $this->createMultipleReconciliations($data);
         }
 
+        // Fall back to single reconciliation creation (backwards compatibility)
+        return parent::handleRecordCreation($data);
+    }
+
+    protected function createMultipleReconciliations(array $data): Model
+    {
+        $labIds = $data['lab_ids'];
+        $useSameSettings = $data['use_same_settings'] ?? true;
+        $labConfigurations = $data['lab_configurations'] ?? [];
+
+        // Validate no labs have ongoing reconciliations
+        $labsWithOngoing = Lab::whereIn('id', $labIds)
+            ->whereHas('reconciliations', function ($query) {
+                $query->where('status', 'ongoing');
+            })
+            ->get();
+
+        if ($labsWithOngoing->isNotEmpty()) {
+            $labNames = $labsWithOngoing->pluck('room_number')->join(', ');
+            Notification::make()
+                ->danger()
+                ->title('Cannot create reconciliations')
+                ->body("The following labs already have ongoing reconciliations: $labNames")
+                ->send();
+
+            throw new \Illuminate\Validation\ValidationException(
+                validator: \Illuminate\Support\Facades\Validator::make([], []),
+                errorBag: 'default'
+            );
+        }
+
+        $createdCount = 0;
+
+        DB::transaction(function () use ($labIds, $useSameSettings, $labConfigurations, $data, &$createdCount) {
+            foreach ($labIds as $labId) {
+                $lab = Lab::findOrFail($labId);
+
+                // Determine settings for this lab
+                if ($useSameSettings) {
+                    $status = $data['status'] ?? 'ongoing';
+                    $notes = $data['notes'] ?? null;
+                    $startedAt = $data['started_at'] ?? ($status === 'ongoing' ? now('America/Edmonton') : null);
+                    $endedAt = $data['ended_at'] ?? ($status === 'completed' ? now('America/Edmonton') : null);
+                } else {
+                    $labConfig = collect($labConfigurations)->firstWhere('lab_id', $labId);
+                    if (!$labConfig) {
+                        continue; // Skip if no configuration found for this lab
+                    }
+                    $status = $labConfig['status'] ?? 'ongoing';
+                    $notes = $labConfig['notes'] ?? null;
+                    $startedAt = $labConfig['started_at'] ?? ($status === 'ongoing' ? now('America/Edmonton') : null);
+                    $endedAt = $labConfig['ended_at'] ?? ($status === 'completed' ? now('America/Edmonton') : null);
+                }
+
+                // Convert dates to Carbon instances if they're strings
+                if ($startedAt && is_string($startedAt)) {
+                    $startedAt = Carbon::parse($startedAt, 'America/Edmonton');
+                }
+                if ($endedAt && is_string($endedAt)) {
+                    $endedAt = Carbon::parse($endedAt, 'America/Edmonton');
+                }
+
+                // Create reconciliation
+                $reconciliation = new Reconciliation;
+                $reconciliation->status = $status;
+                $reconciliation->notes = $notes;
+                $reconciliation->lab_id = $labId;
+                $reconciliation->started_at = $startedAt;
+                $reconciliation->ended_at = $endedAt;
+                $reconciliation->save();
+
+                // Generate reconciliation items for all containers in this lab
+                foreach ($lab->storageLocations as $storageLocation) {
+                    foreach ($storageLocation->containers as $container) {
+                        $reconciliationItem = new ReconciliationItem;
+                        $reconciliationItem->container()->associate($container);
+                        $reconciliationItem->reconciliation()->associate($reconciliation);
+                        $reconciliationItem->save();
+                    }
+                }
+
+                $createdCount++;
+            }
+        });
+
+        // Set record to the last created one (for compatibility with afterCreate hooks)
+        $this->record = Reconciliation::whereIn('lab_id', $labIds)->latest()->first();
+
+        // Show success notification
+        Notification::make()
+            ->success()
+            ->title('Reconciliations created')
+            ->body("Successfully created {$createdCount} reconciliation(s).")
+            ->send();
+
+        return $this->record;
+    }
+
+    protected function afterCreate(): void
+    {
+        // Only run if we have a valid record with lab_id (single creation path)
+        if ($this->record && $this->record->lab_id) {
+            $reconciliation = $this->record;
+            $lab = Lab::find($reconciliation->lab_id);
+
+            if ($lab) {
+                foreach ($lab->storageLocations as $storageLocation) {
+                    foreach ($storageLocation->containers as $container) {
+                        $reconciliationItem = new ReconciliationItem;
+                        $reconciliationItem->container()->associate($container);
+                        $reconciliationItem->reconciliation()->associate($reconciliation);
+                        $reconciliationItem->save();
+                    }
+                }
+            }
+        }
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+
+    protected function getFormActions(): array
+    {
+        return [
+            $this->getCreateFormAction()
+                ->label('Create')
+                ->disabled(function () {
+                    // Check if we have lab_ids selected (which means we're on step 2)
+                    // If lab_ids is empty or not set, we're on step 1
+                    $data = $this->form->getRawState();
+                    $labIds = $data['lab_ids'] ?? null;
+                    
+                    // Disable if no labs selected (still on first step)
+                    return empty($labIds);
+                }),
+        ];
     }
 }

--- a/app/Filament/Resources/ReconciliationResource/Pages/EditReconciliation.php
+++ b/app/Filament/Resources/ReconciliationResource/Pages/EditReconciliation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Filament\Resources\ReconciliationResource\Pages;
+
+use App\Filament\Resources\ReconciliationResource\ReconciliationResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditReconciliation extends EditRecord
+{
+    protected static string $resource = ReconciliationResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+
+    protected function getFormActions(): array
+    {
+        return [
+            $this->getSaveFormAction(),
+            $this->getCancelFormAction(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+}
+

--- a/app/Filament/Resources/ReconciliationResource/Pages/ViewReconciliation.php
+++ b/app/Filament/Resources/ReconciliationResource/Pages/ViewReconciliation.php
@@ -3,10 +3,69 @@
 namespace App\Filament\Resources\ReconciliationResource\Pages;
 
 use App\Filament\Resources\ReconciliationResource\ReconciliationResource;
+use Filament\Actions;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewReconciliation extends ViewRecord
 {
     protected static string $resource = ReconciliationResource::class;
 
+    public function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Reconciliation Details')
+                    ->collapsible()
+                    ->collapsed()
+                    ->schema([
+                        TextEntry::make('lab.room_number')
+                            ->label('Lab')
+                            ->icon('heroicon-o-building-office'),
+                        TextEntry::make('status')
+                            ->label('Status')
+                            ->formatStateUsing(fn (string $state): string => ucfirst($state))
+                            ->badge()
+                            ->color(fn (string $state): string => match ($state) {
+                                'stopped' => 'danger',
+                                'ongoing' => 'warning',
+                                'completed' => 'success',
+                                default => 'gray',
+                            })
+                            ->icon(fn (string $state): string => match ($state) {
+                                'stopped' => 'heroicon-o-no-symbol',
+                                'ongoing' => 'heroicon-o-pencil',
+                                'completed' => 'heroicon-o-check-circle',
+                                default => 'heroicon-o-question-mark-circle',
+                            }),
+                        TextEntry::make('started_at')
+                            ->label('Started At')
+                            ->dateTime()
+                            ->icon('heroicon-o-clock')
+                            ->placeholder('Not started'),
+                        TextEntry::make('ended_at')
+                            ->label('Ended At')
+                            ->dateTime()
+                            ->icon('heroicon-o-clock')
+                            ->placeholder('Not ended'),
+                        TextEntry::make('notes')
+                            ->label('Notes')
+                            ->icon('heroicon-o-document-text')
+                            ->placeholder('No notes')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2)
+                    ->compact(),
+            ]);
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make()
+                ->slideOver(),
+        ];
+    }
 }

--- a/app/Filament/Resources/ReconciliationResource/ReconciliationForm.php
+++ b/app/Filament/Resources/ReconciliationResource/ReconciliationForm.php
@@ -3,13 +3,250 @@
 namespace App\Filament\Resources\ReconciliationResource;
 
 use App\Models\Lab;
+use Carbon\Carbon;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Wizard;
+use Filament\Forms\Components\Wizard\Step;
 
 class ReconciliationForm
 {
-    public static function make(): array
+    public static function make(?string $context = null): array
+    {
+        // Only show wizard on create
+        if ($context !== 'create') {
+            return static::makeSimpleForm();
+        }
+
+        return [
+            Wizard::make([
+                Step::make('Select Labs')
+                    ->schema([
+                        Select::make('lab_ids')
+                            ->label('Labs')
+                            ->options(function () {
+                                return Lab::all()->pluck('room_number', 'id');
+                            })
+                            ->multiple()
+                            ->required()
+                            ->searchable()
+                            ->live()
+                            ->disableOptionWhen(function ($value) {
+                                $lab = Lab::find($value);
+
+                                return $lab && $lab->hasOngoingReconciliation();
+                            })
+                            ->helperText(function () {
+                                $ongoingLabs = Lab::whereHas('reconciliations', function ($query) {
+                                    $query->where('status', 'ongoing');
+                                })->get();
+
+                                if ($ongoingLabs->isNotEmpty()) {
+                                    $labs = $ongoingLabs->pluck('room_number')->join(', ');
+
+                                    return "The following labs are currently being reconciled and cannot be selected: $labs";
+                                }
+
+                                return null;
+                            }),
+                    ]),
+                Step::make('Configure Reconciliations')
+                    ->schema([
+                        Checkbox::make('use_same_settings')
+                            ->label('Use same settings for all labs')
+                            ->default(true)
+                            ->live()
+                            ->afterStateUpdated(function ($set, $state, $get, $component) {
+                                // When unchecked, populate the repeater with items for all selected labs
+                                if ($state === false) {
+                                    $labIds = $get('lab_ids') ?? [];
+                                    if (!empty($labIds)) {
+                                        $items = [];
+                                        foreach ($labIds as $labId) {
+                                            $items[] = [
+                                                'lab_id' => $labId,
+                                                'status' => 'ongoing',
+                                                'notes' => null,
+                                                'started_at' => Carbon::now('America/Edmonton')->format('Y-m-d H:i:s'),
+                                                'ended_at' => null,
+                                            ];
+                                        }
+                                        $set('lab_configurations', $items);
+                                    }
+                                }
+                            })
+                            ->columnSpanFull(),
+                        Select::make('status')
+                            ->options([
+                                'ongoing' => 'Ongoing',
+                                'completed' => 'Completed',
+                                'stopped' => 'Stopped',
+                            ])
+                            ->required()
+                            ->default('ongoing')
+                            ->visible(fn ($get) => $get('use_same_settings') === true)
+                            ->afterStateUpdated(function ($set, $state) {
+                                if ($state === 'ongoing') {
+                                    $set('started_at', Carbon::now('America/Edmonton'));
+                                }
+                                if ($state === 'completed') {
+                                    $set('ended_at', Carbon::now('America/Edmonton'));
+                                } else {
+                                    $set('ended_at', null);
+                                }
+                            }),
+                        Textarea::make('notes')
+                            ->columnSpanFull()
+                            ->visible(fn ($get) => $get('use_same_settings') === true),
+                        DateTimePicker::make('started_at')
+                            ->hidden(fn ($get) => $get('status') !== 'ongoing' || $get('use_same_settings') !== true)
+                            ->required(fn ($get) => $get('status') === 'ongoing' && $get('use_same_settings') === true)
+                            ->default(fn () => Carbon::now('America/Edmonton'))
+                            ->timezone('America/Edmonton')
+                            ->seconds(false)
+                            ->visible(fn ($get) => $get('use_same_settings') === true),
+                        DateTimePicker::make('ended_at')
+                            ->hidden(fn ($get) => $get('status') !== 'completed' || $get('use_same_settings') !== true)
+                            ->timezone('America/Edmonton')
+                            ->seconds(false)
+                            ->visible(fn ($get) => $get('use_same_settings') === true),
+                        Repeater::make('lab_configurations')
+                            ->schema([
+                                Select::make('lab_id')
+                                    ->label('Lab')
+                                    ->options(function ($get) {
+                                        $selectedLabIds = $get('../../lab_ids') ?? [];
+                                        return Lab::whereIn('id', $selectedLabIds)
+                                            ->pluck('room_number', 'id');
+                                    })
+                                    ->required()
+                                    ->disabled()
+                                    ->dehydrated(),
+                                Select::make('status')
+                                    ->options([
+                                        'ongoing' => 'Ongoing',
+                                        'completed' => 'Completed',
+                                        'stopped' => 'Stopped',
+                                    ])
+                                    ->required()
+                                    ->default('ongoing')
+                                    ->live()
+                                    ->afterStateUpdated(function ($set, $state) {
+                                        if ($state === 'ongoing') {
+                                            $set('started_at', Carbon::now('America/Edmonton'));
+                                            $set('ended_at', null);
+                                        }
+                                        if ($state === 'completed') {
+                                            $set('ended_at', Carbon::now('America/Edmonton'));
+                                        }
+                                        if ($state === 'stopped') {
+                                            $set('ended_at', null);
+                                        }
+                                    }),
+                                Textarea::make('notes')
+                                    ->columnSpanFull(),
+                                DateTimePicker::make('started_at')
+                                    ->hidden(fn ($get) => $get('status') !== 'ongoing')
+                                    ->required(fn ($get) => $get('status') === 'ongoing')
+                                    ->default(fn () => Carbon::now('America/Edmonton'))
+                                    ->timezone('America/Edmonton')
+                                    ->seconds(false),
+                                DateTimePicker::make('ended_at')
+                                    ->hidden(fn ($get) => $get('status') !== 'completed')
+                                    ->timezone('America/Edmonton')
+                                    ->seconds(false),
+                            ])
+                            ->columns(2)
+                            ->visible(fn ($get) => $get('use_same_settings') !== true)
+                            ->defaultItems(0)
+                            ->addable(false)
+                            ->reorderable(false)
+                            ->deletable(false)
+                            ->live()
+                            ->afterStateHydrated(function ($component, $state, $get) {
+                                $useSameSettings = $get('use_same_settings');
+                                if ($useSameSettings === true) {
+                                    $component->state([]);
+                                    return;
+                                }
+                                
+                                $labIds = $get('lab_ids') ?? [];
+                                if (empty($labIds)) {
+                                    $component->state([]);
+                                    return;
+                                }
+                                
+                                // Only populate if state is empty or doesn't match lab_ids
+                                $currentLabIds = collect($state ?? [])->pluck('lab_id')->toArray();
+                                sort($labIds);
+                                sort($currentLabIds);
+                                
+                                if ($labIds !== $currentLabIds || empty($state)) {
+                                    $items = [];
+                                    foreach ($labIds as $labId) {
+                                        $existingItem = collect($state ?? [])->firstWhere('lab_id', $labId);
+                                        if ($existingItem) {
+                                            $items[] = $existingItem;
+                                        } else {
+                                            $items[] = [
+                                                'lab_id' => $labId,
+                                                'status' => 'ongoing',
+                                                'notes' => null,
+                                                'started_at' => Carbon::now('America/Edmonton')->format('Y-m-d H:i:s'),
+                                                'ended_at' => null,
+                                            ];
+                                        }
+                                    }
+                                    $component->state($items);
+                                }
+                            })
+                            ->afterStateUpdated(function ($component, $state, $get) {
+                                $useSameSettings = $get('use_same_settings');
+                                if ($useSameSettings === true) {
+                                    return;
+                                }
+                                
+                                $labIds = $get('lab_ids') ?? [];
+                                if (empty($labIds)) {
+                                    $component->state([]);
+                                    return;
+                                }
+                                
+                                $currentLabIds = collect($state ?? [])->pluck('lab_id')->toArray();
+                                sort($labIds);
+                                sort($currentLabIds);
+                                
+                                if ($labIds !== $currentLabIds) {
+                                    $items = [];
+                                    foreach ($labIds as $labId) {
+                                        $existingItem = collect($state ?? [])->firstWhere('lab_id', $labId);
+                                        if ($existingItem) {
+                                            $items[] = $existingItem;
+                                        } else {
+                                            $items[] = [
+                                                'lab_id' => $labId,
+                                                'status' => 'ongoing',
+                                                'notes' => null,
+                                                'started_at' => Carbon::now('America/Edmonton')->format('Y-m-d H:i:s'),
+                                                'ended_at' => null,
+                                            ];
+                                        }
+                                    }
+                                    $component->state($items);
+                                }
+                            })
+                            ->dehydrated(),
+                    ]),
+            ])
+                ->columnSpanFull()
+                ->persistStepInQueryString(false),
+        ];
+    }
+
+    protected static function makeSimpleForm(): array
     {
         return [
             Select::make('status')
@@ -22,10 +259,10 @@ class ReconciliationForm
                 ->default('ongoing')
                 ->afterStateUpdated(function ($set, $state) {
                     if ($state === 'ongoing') {
-                        $set('started_at', now());
+                        $set('started_at', Carbon::now('America/Edmonton'));
                     }
                     if ($state === 'completed') {
-                        $set('ended_at', now());
+                        $set('ended_at', Carbon::now('America/Edmonton'));
                     } else {
                         $set('ended_at', null);
                     }
@@ -34,13 +271,14 @@ class ReconciliationForm
                 ->columnSpanFull(),
             DateTimePicker::make('started_at')
                 ->hidden(fn ($get) => $get('status') !== 'ongoing')
-                ->date('started_at')
                 ->required()
-                ->closeOnDateSelection(),
+                ->default(fn () => Carbon::now('America/Edmonton'))
+                ->timezone('America/Edmonton')
+                ->seconds(false),
             DateTimePicker::make('ended_at')
                 ->hidden(fn ($get) => $get('status') !== 'completed')
-                ->date('ended_at')
-                ->closeOnDateSelection(),
+                ->timezone('America/Edmonton')
+                ->seconds(false),
             Select::make('lab_id')
                 ->label('Lab')
                 ->options(Lab::all()->pluck('room_number', 'id'))

--- a/app/Filament/Resources/ReconciliationResource/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource/ReconciliationResource.php
@@ -19,7 +19,23 @@ class ReconciliationResource extends Resource
     public static function form(Form $form): Form
     {
         return $form
-            ->schema(ReconciliationForm::make());
+            ->schema(function (Form $form) {
+                // Check if we're creating by checking the Livewire component type
+                // The form's schema closure has access to the Livewire component through getLivewire()
+                $isCreate = false;
+                
+                if (method_exists($form, 'getLivewire')) {
+                    try {
+                        $livewire = $form->getLivewire();
+                        $isCreate = $livewire instanceof \App\Filament\Resources\ReconciliationResource\Pages\CreateReconciliation;
+                    } catch (\Exception $e) {
+                        // If getLivewire fails, default to edit form
+                        $isCreate = false;
+                    }
+                }
+                
+                return ReconciliationForm::make($isCreate ? 'create' : 'edit');
+            });
     }
 
     public static function table(Table $table): Table
@@ -37,8 +53,8 @@ class ReconciliationResource extends Resource
         return [
             'index' => Pages\ListReconciliations::route('/'),
             'create' => Pages\CreateReconciliation::route('/create'),
+            'edit' => Pages\EditReconciliation::route('/{record}/edit'),
             'view' => Pages\ViewReconciliation::route('/{record}'),
-
         ];
     }
 

--- a/app/Filament/Resources/ReconciliationResource/ReconciliationTable.php
+++ b/app/Filament/Resources/ReconciliationResource/ReconciliationTable.php
@@ -9,8 +9,6 @@ use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DeleteBulkAction;
-use Filament\Tables\Actions\EditAction;
-use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Grouping\Group;
@@ -66,8 +64,7 @@ class ReconciliationTable
     public static function actions(): array
     {
         return [
-            EditAction::make(),
-            ViewAction::make(),
+            // No actions - clicking row navigates to view page
         ];
     }
 

--- a/app/Filament/Resources/UserResource/UserForm.php
+++ b/app/Filament/Resources/UserResource/UserForm.php
@@ -14,8 +14,7 @@ class UserForm
             TextInput::make('name')
                 ->required()
                 ->maxLength(255),
-            TextInput::make('email')
-                ->email()
+            TextInput::make('username')
                 ->required()
                 ->maxLength(255)
                 ->unique(ignoreRecord: true),

--- a/app/Filament/Resources/UserResource/UserTable.php
+++ b/app/Filament/Resources/UserResource/UserTable.php
@@ -15,7 +15,7 @@ class UserTable
         return [
             TextColumn::make('name')
                 ->searchable(),
-            TextColumn::make('email')
+            TextColumn::make('username')
                 ->searchable(),
             TextColumn::make('roles.name')
                 ->badge(),

--- a/app/Livewire/HazardClassSelect.php
+++ b/app/Livewire/HazardClassSelect.php
@@ -24,20 +24,17 @@ final class HazardClassSelect extends CheckboxList
                     .'</span>';
             }
 
-            return '<span class="inline-flex items-start gap-2">'
+            return '<span class="inline-flex items-center gap-2 w-full">'
                 .view('filament::components.icon', [
                     'icon' => $record->icon,
-                    'class' => 'w-8 h-8 text-primary-600 shrink-0',
+                    'class' => 'w-10 h-10 text-primary-600 shrink-0',
                 ])->render()
-                .'<span>'.e($record->class_name).'</span>'
+                .'<span class="text-xs font-medium leading-tight break-words flex-1 min-w-0">'.e($record->class_name).'</span>'
                 .'</span>';
         });
 
         $this->allowHtml();
 
-        // Display in two columns.
-        $this->columns(2);
-
-        $this->label('WHMIS Hazard Classes');
+        $this->columns(3);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,8 +16,7 @@ use Illuminate\Notifications\Notifiable;
  *
  * @property int id
  * @property string name
- * @property string email
- * @property DateTime email_verified_at
+ * @property string username
  * @property string password
  * @property string remember_token
  * @property DateTime created_at
@@ -35,9 +34,19 @@ class User extends Authenticatable implements FilamentUser
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the username for Filament authentication.
+     * Used by the login form.
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
     }
 
     public function canAccessPanel(Panel $panel): bool

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Pages\CustomLogin;
 use App\Filament\Resources\ChemicalResource\ChemicalResource;
 use App\Filament\Resources\ContainerResource\ContainerResource;
 use App\Filament\Resources\LabResource\LabResource;
@@ -34,7 +35,7 @@ class AdminPanelProvider extends PanelProvider
             ->databaseNotifications()
             ->id('admin')
             ->path('')
-            ->login()
+            ->login(CustomLogin::class)
             ->topNavigation()
             ->breadcrumbs(false)
             ->colors([

--- a/app/Services/Container/ContainerExporter.php
+++ b/app/Services/Container/ContainerExporter.php
@@ -6,6 +6,7 @@ use App\Models\Container;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
+use Illuminate\Database\Eloquent\Builder;
 
 class ContainerExporter extends Exporter
 {
@@ -28,10 +29,26 @@ class ContainerExporter extends Exporter
                 ->label('Room'),
             ExportColumn::make('storageLocation.name')
                 ->label('Location'),
-            ExportColumn::make('chemical.ishazardous')
-                ->label('Hazardous'),
+            ExportColumn::make('chemical.whmisHazardClasses.class_name')
+                ->label('WHMIS Hazard Classes')
+                ->distinctList()
+                ->default('None'),
+            ExportColumn::make('lastEditAuthor.name')
+                ->label('Last Edited By')
+                ->default('Unknown'),
 
         ];
+    }
+
+    public static function modifyQuery(Builder $query): Builder
+    {
+        return parent::modifyQuery($query)
+            ->with([
+                'chemical.whmisHazardClasses',
+                'storageLocation.lab',
+                'unitOfMeasure',
+                'lastEditAuthor',
+            ]);
     }
 
     public static function getCompletedNotificationBody(Export $export): string

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,10 +24,12 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $name = fake()->name();
+        $username = strtolower(str_replace(' ', '.', $name));
+        
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
+            'name' => $name,
+            'username' => $username,
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];

--- a/database/migrations/2025_10_31_152916_fix_duplicate_whmis_hazard_classes.php
+++ b/database/migrations/2025_10_31_152916_fix_duplicate_whmis_hazard_classes.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Mapping: duplicate_id => original_id
+        $duplicateMapping = [
+            12 => 1, // Harmful / Irritant
+            13 => 2, // Explosive
+            14 => 3, // Biohazardous
+        ];
+
+        // Step 1: Migrate pivot table relationships
+        // Handle each duplicate ID mapping
+        foreach ($duplicateMapping as $duplicateId => $originalId) {
+            // Check if duplicate ID exists in the hazard classes table
+            $duplicateExists = DB::table('whmis_hazard_classes')
+                ->where('id', $duplicateId)
+                ->exists();
+
+            if (!$duplicateExists) {
+                // Skip if duplicate doesn't exist (idempotent)
+                continue;
+            }
+
+            // Get all pivot table entries using the duplicate ID
+            $pivotEntries = DB::table('chemical_whmis_hazard_class')
+                ->where('whmis_hazard_class_id', $duplicateId)
+                ->get();
+
+            foreach ($pivotEntries as $entry) {
+                $chemicalId = $entry->chemical_id;
+
+                // Check if this chemical already has a relationship with the original ID
+                $existingRelationship = DB::table('chemical_whmis_hazard_class')
+                    ->where('chemical_id', $chemicalId)
+                    ->where('whmis_hazard_class_id', $originalId)
+                    ->exists();
+
+                if ($existingRelationship) {
+                    // If original relationship exists, just delete the duplicate relationship
+                    DB::table('chemical_whmis_hazard_class')
+                        ->where('chemical_id', $chemicalId)
+                        ->where('whmis_hazard_class_id', $duplicateId)
+                        ->delete();
+                } else {
+                    // Update the relationship to point to the original ID
+                    DB::table('chemical_whmis_hazard_class')
+                        ->where('chemical_id', $chemicalId)
+                        ->where('whmis_hazard_class_id', $duplicateId)
+                        ->update(['whmis_hazard_class_id' => $originalId]);
+                }
+            }
+        }
+
+        // Step 2: Delete duplicate records from whmis_hazard_classes table
+        // Only delete if they still exist
+        DB::table('whmis_hazard_classes')
+            ->whereIn('id', array_keys($duplicateMapping))
+            ->delete();
+
+        // Step 3: Add unique constraint on class_name to prevent future duplicates
+        Schema::table('whmis_hazard_classes', function (Blueprint $table): void {
+            $table->unique('class_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Remove unique constraint
+        Schema::table('whmis_hazard_classes', function (Blueprint $table): void {
+            $table->dropUnique(['class_name']);
+        });
+
+        // This does not restore the deleted duplicate records.
+    }
+};

--- a/database/migrations/2025_10_31_155249_replace_email_with_username.php
+++ b/database/migrations/2025_10_31_155249_replace_email_with_username.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add username column to users table
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('username', 255)->after('name');
+        });
+
+        // Generate usernames from existing names
+        $users = DB::table('users')->get();
+        $usernameCounts = [];
+        
+        foreach ($users as $user) {
+            $baseUsername = strtolower(str_replace(' ', '.', trim($user->name)));
+            $username = $baseUsername;
+            $counter = 1;
+            
+            // Ensure uniqueness
+            while (isset($usernameCounts[$username])) {
+                $username = $baseUsername . '.' . $counter;
+                $counter++;
+            }
+            
+            $usernameCounts[$username] = true;
+            
+            DB::table('users')
+                ->where('id', $user->id)
+                ->update(['username' => $username]);
+        }
+
+        // Make username unique and not null
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('username', 255)->unique()->change();
+        });
+
+        // Drop email-related columns
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_email_unique');
+            $table->dropColumn(['email', 'email_verified_at']);
+        });
+
+        // Update password_reset_tokens table
+        if (Schema::hasTable('password_reset_tokens')) {
+            // Drop primary key
+            DB::statement('ALTER TABLE password_reset_tokens DROP PRIMARY KEY');
+            
+            // Rename email column to username
+            DB::statement('ALTER TABLE password_reset_tokens CHANGE email username VARCHAR(255) NOT NULL');
+            
+            // Add primary key on username
+            DB::statement('ALTER TABLE password_reset_tokens ADD PRIMARY KEY (username)');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Revert password_reset_tokens table
+        if (Schema::hasTable('password_reset_tokens')) {
+            // Drop primary key
+            DB::statement('ALTER TABLE password_reset_tokens DROP PRIMARY KEY');
+            
+            // Rename username column back to email
+            DB::statement('ALTER TABLE password_reset_tokens CHANGE username email VARCHAR(255) NOT NULL');
+            
+            // Add primary key on email
+            DB::statement('ALTER TABLE password_reset_tokens ADD PRIMARY KEY (email)');
+        }
+
+        // Re-add email columns to users table
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('email', 255)->after('name');
+            $table->timestamp('email_verified_at')->nullable()->after('email');
+        });
+
+        // Drop username column
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_username_unique');
+            $table->dropColumn('username');
+        });
+
+        // Re-add unique constraint on email
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('email');
+        });
+    }
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -6,7 +6,7 @@ use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
-
+use Filament\Forms\Form;
 class UserSeeder extends Seeder
 {
     public function run(): void
@@ -14,13 +14,13 @@ class UserSeeder extends Seeder
         // Create the admin user
         $adminUser = User::create([
             'name' => 'Test Admin',
-            'email' => 'test@test.com',
+            'username' => 'test.admin',
             'password' => Hash::make('test'),
         ]);
 
         $viewUser = User::create([
             'name' => 'Test Viewer',
-            'email' => 'test1@test.com',
+            'username' => 'test.viewer',
             'password' => Hash::make('test'),
         ]);
 

--- a/database/seeders/WhmisHazardClassSeeder.php
+++ b/database/seeders/WhmisHazardClassSeeder.php
@@ -62,6 +62,14 @@ class WhmisHazardClassSeeder extends Seeder
             ],
         ];
 
-        DB::table('whmis_hazard_classes')->insert($hazardClasses);
+        // Use updateOrInsert to prevent duplicates and allow updates if classes already exist
+        // In one of the migrations I introduced duplicates, so hopefully this keeps it from breaking in the future 
+        // if the db needs to be reseeded. 
+        foreach ($hazardClasses as $class) {
+            DB::table('whmis_hazard_classes')->updateOrInsert(
+                ['class_name' => $class['class_name']],
+                $class
+            );
+        }
     }
 }

--- a/tests/Feature/ContainerImporterTest.php
+++ b/tests/Feature/ContainerImporterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Enums\WhmisPictogram;
+use App\Models\Chemical;
+use App\Models\Container;
+use App\Models\Lab;
+use App\Models\StorageLocation;
+use App\Models\UnitOfMeasure;
+use App\Models\User;
+use App\Models\WhmisHazardClass;
+use App\Services\Container\ContainerImporter;
+use Filament\Actions\Imports\Models\Import as ImportModel;
+use Filament\Actions\Imports\Exceptions\RowImportFailedException;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+function createImportForUser(User $user): ImportModel {
+    return ImportModel::create([
+        'user_id' => $user->id,
+        'file_name' => 'containers.csv',
+        'file_path' => 'containers.csv',
+        'importer' => ContainerImporter::class,
+        'processed_rows' => 0,
+        'successful_rows' => 0,
+        'total_rows' => 1,
+    ]);
+}
+
+function defaultColumnMap(): array {
+    return [
+        'barcode' => 'Barcode',
+        'chemical.cas' => 'CAS #',
+        'chemical.whmisHazardClasses.class_name' => 'WHMIS Hazard Classes',
+        'quantity' => 'Quantity',
+        'unitofmeasure.abbreviation' => 'Unit',
+        'storageLocation.lab.room_number' => 'Room',
+        'storageLocation.name' => 'Location',
+        'lastEditAuthor.name' => 'Last Edited By',
+    ];
+}
+
+it('imports a container row using exporter columns', function () {
+    $user = User::factory()->create();
+    auth()->login($user);
+
+    $hazardClass = WhmisHazardClass::firstOrCreate(
+        ['class_name' => 'Flammable'],
+        [
+            'description' => 'Highly flammable material',
+            'symbol' => WhmisPictogram::FLAME,
+        ]
+    );
+
+    $chemical = Chemical::factory()->create([
+        'cas' => '67-64-1',
+        'name' => 'Acetone',
+    ]);
+    $chemical->whmisHazardClasses()->sync([$hazardClass->id]);
+
+    $unit = UnitOfMeasure::firstOrCreate(
+        ['abbreviation' => 'L'],
+        ['name' => 'Litres']
+    );
+
+    $lab = Lab::factory()->create([
+        'room_number' => 'B203',
+    ]);
+
+    $location = StorageLocation::factory()
+        ->for($lab)
+        ->create([
+            'name' => 'Shelf 2',
+        ]);
+
+    $import = createImportForUser($user);
+    $importer = $import->getImporter(defaultColumnMap(), []);
+
+    $barcode = 'MRUC92PH8W';
+    $hazardNames = $chemical->whmisHazardClasses->pluck('class_name')->join(', ');
+
+    $row = [
+        'Barcode' => $barcode,
+        'CAS #' => $chemical->cas,
+        'WHMIS Hazard Classes' => $hazardNames,
+        'Quantity' => '314.39',
+        'Unit' => $unit->abbreviation,
+        'Room' => $lab->room_number,
+        'Location' => $location->name,
+        'Last Edited By' => $user->name,
+    ];
+
+    ($importer)($row);
+
+    $container = Container::where('barcode', $barcode)->first();
+
+    expect($container)->not()->toBeNull();
+    expect($container->chemical_id)->toEqual($chemical->id);
+    expect($container->unit_of_measure_id)->toEqual($unit->id);
+    expect($container->storage_location_id)->toEqual($location->id);
+    expect($container->quantity)->toEqual(314.39);
+    expect($container->last_edit_author_id)->toEqual($user->id);
+});
+
+it('fails rows when related lookups are missing', function () {
+    $user = User::factory()->create();
+    auth()->login($user);
+
+    $import = createImportForUser($user);
+    $importer = $import->getImporter(defaultColumnMap(), []);
+
+    $row = [
+        'Barcode' => 'MISSING01',
+        'CAS #' => '00-00-0',
+        'WHMIS Hazard Classes' => 'Unknown',
+        'Quantity' => '10',
+        'Unit' => 'L',
+        'Room' => 'B999',
+        'Location' => 'Shelf X',
+        'Last Edited By' => 'Tester',
+    ];
+
+    $existingCount = Container::count();
+
+    expect(fn () => ($importer)($row))
+        ->toThrow(RowImportFailedException::class, 'Unable to import container row: no chemical was found with CAS # [00-00-0].');
+
+    expect(Container::where('barcode', 'MISSING01')->exists())->toBeFalse();
+    expect(Container::count())->toBe($existingCount);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,47 +1,58 @@
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind a different classes or traits.
-|
-*/
+namespace {
 
-pest()->extend(Tests\TestCase::class)
-    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature', 'Unit');
+    /*
+    |--------------------------------------------------------------------------
+    | Test Case
+    |--------------------------------------------------------------------------
+    |
+    | The closure you provide to your test functions is always bound to a specific PHPUnit test
+    | case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+    | need to change it using the "pest()" function to bind a different classes or traits.
+    |
+    */
 
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
+    pest()->extend(Tests\TestCase::class)
+        ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+        ->in('Feature', 'Unit');
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
+    /*
+    |--------------------------------------------------------------------------
+    | Expectations
+    |--------------------------------------------------------------------------
+    |
+    | When you're writing tests, you often need to check that values meet certain conditions. The
+    | "expect()" function gives you access to a set of "expectations" methods that you can use
+    | to assert different things. Of course, you may extend the Expectation API at any time.
+    |
+    */
 
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
+    expect()->extend('toBeOne', function () {
+        return $this->toBe(1);
+    });
 
-function something()
-{
-    // ..
+    /*
+    |--------------------------------------------------------------------------
+    | Functions
+    |--------------------------------------------------------------------------
+    |
+    | While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+    | project that you don't want to repeat in every file. Here you can also expose helpers as
+    | global functions to help you to reduce the number of lines of code in your test files.
+    |
+    */
+}
+
+namespace Pest\Laravel {
+    use Illuminate\Support\Facades\Auth;
+
+    if (! function_exists(__NAMESPACE__ . '\\actingAs')) {
+        function actingAs($user, ?string $driver = null)
+        {
+            Auth::guard($driver)->login($user);
+
+            return $user;
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the Filament admin panel, focusing on improved user experience for login, chemical form layout, container grouping, and especially reconciliation workflows. The most significant changes include a custom login page using usernames, advanced multi-lab reconciliation creation with validation and notifications, and improved UI for reconciliation management.

**Authentication:**
- Added a custom login page (`CustomLogin`) that uses a username field instead of an email field for authentication in the admin panel.

**Reconciliation Workflow Improvements:**
- Implemented multi-lab reconciliation creation in `CreateReconciliation` with validation to prevent duplicate ongoing reconciliations, transactional creation logic, and user notifications. The form now disables the "Create" button until labs are selected and redirects to the index page after creation. 
- Added `EditReconciliation` and enhanced `ViewReconciliation` pages: `EditReconciliation` allows saving, cancelling, and deleting, while `ViewReconciliation` displays reconciliation details in a collapsible section with status badges and icons, and provides a slide-over edit action. 

**UI/UX Enhancements:**
- Updated the chemical form layout to use a two-column grid for CAS and name fields, and made the WHMIS Hazard Classes selector span the full width for better usability. 
- Enabled grouping of containers in the container resource table by lab room number and storage location, with collapsible groups for easier navigation and organization.